### PR TITLE
More Options from MQTT Side

### DIFF
--- a/ip150_mqtt.py
+++ b/ip150_mqtt.py
@@ -36,6 +36,8 @@ class IP150_MQTT():
 		'DISARM': 'Disarm',
 		'ARM_AWAY': 'Arm',
 		'ARM_HOME': 'Arm_sleep'
+		'ARM_SLEEP': 'Arm_sleep'
+		'ARM_STAY': 'Arm_stay' 
 		}
 
 	def __init__(self, opt_file):


### PR DESCRIPTION
Now accepts: 
		'DISARM': 'Disarm',
		'ARM_AWAY': 'Arm',
		'ARM_HOME': 'Arm_sleep'
		'ARM_SLEEP': 'Arm_sleep'
		'ARM_STAY': 'Arm_stay' 

for configuration.yalm
option A:
alarm_control_panel:
 - platform: mqtt
   name: House Paradox
   state_topic: "paradox/alarm/state/1"
   command_topic: "paradox/alarm/cmnd/1"
   payload_disarm: "DISARM"
   payload_arm_home: "ARM_SLEEP"
   payload_arm_away: "ARM_AWAY"

Option B
alarm_control_panel:
 - platform: mqtt
   name: House Paradox
   state_topic: "paradox/alarm/state/1"
   command_topic: "paradox/alarm/cmnd/1"
   payload_disarm: "DISARM"
   payload_arm_home: "ARM_STAY"
   payload_arm_away: "ARM_AWAY"

Currently the HASS MQTT ALARM ONLY SUPPORTS 3 PAYLOADS. (Disarm,Home,Away) this allows you to customize the Home, to be either stay or sleep, depending on what suits better.
CyberTza